### PR TITLE
EC2에서 빌드 후 실행시, 사용하는 DB 명시하지 않아 발생하는 에러 해결 

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,7 @@ spring:
     activate:
       on-profile: "dev"
   jpa:
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     hibernate:
       ddl-auto: update
       naming:
@@ -66,6 +67,7 @@ spring:
     activate:
       on-profile: "local"
   jpa:
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     hibernate:
       ddl-auto: update
       naming:


### PR DESCRIPTION
## Summary
- Close #11 

<br>

## Changes 
- 애플리케이션 설정파일의 spring.jpa.database-platform설정값에 사용하는 DB 명시

<br>

## To Reviewers

<br>