### PR TITLE
보안을 위해 Refresh Token을 Cookie에서 활용하도록 수정

### DIFF
--- a/src/main/java/project/seatsence/global/config/filter/JwtFilter.java
+++ b/src/main/java/project/seatsence/global/config/filter/JwtFilter.java
@@ -7,6 +7,7 @@ import static project.seatsence.global.constants.Constants.TOKEN_AUTH_TYPE;
 import java.io.IOException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +58,10 @@ public class JwtFilter extends OncePerRequestFilter {
                     && jwtProvider.validateToken(refreshToken) == JwtState.ACCESS) {
                 String newRefreshToken = jwtProvider.reIssueRefreshToken(refreshToken);
                 if (newRefreshToken != null) {
-                    response.setHeader(REFRESH_HEADER, TOKEN_AUTH_TYPE + newRefreshToken);
+                    //                    response.setHeader(REFRESH_HEADER, TOKEN_AUTH_TYPE +
+                    // newRefreshToken);
+                    Cookie refreshTokenCookie = jwtProvider.createCookie(newRefreshToken);
+                    response.addCookie(refreshTokenCookie);
 
                     Authentication authentication = jwtProvider.getAuthentication(refreshToken);
                     response.setHeader(

--- a/src/main/java/project/seatsence/global/config/filter/JwtFilter.java
+++ b/src/main/java/project/seatsence/global/config/filter/JwtFilter.java
@@ -1,7 +1,6 @@
 package project.seatsence.global.config.filter;
 
 import static project.seatsence.global.constants.Constants.AUTHORIZATION_HEADER;
-import static project.seatsence.global.constants.Constants.REFRESH_HEADER;
 import static project.seatsence.global.constants.Constants.TOKEN_AUTH_TYPE;
 
 import java.io.IOException;
@@ -40,7 +39,7 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
-        String accessToken = resolveToken(request, AUTHORIZATION_HEADER);
+        String accessToken = resolveTokenFromHeader(request, AUTHORIZATION_HEADER);
 
         if (accessToken == null) {
             filterChain.doFilter(request, response);
@@ -53,13 +52,11 @@ public class JwtFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } else if (accessToken != null
                 && jwtProvider.validateToken(accessToken) == JwtState.EXPIRED) {
-            String refreshToken = resolveToken(request, REFRESH_HEADER);
+            String refreshToken = resolveTokenFromCookie(request);
             if (refreshToken != null
                     && jwtProvider.validateToken(refreshToken) == JwtState.ACCESS) {
                 String newRefreshToken = jwtProvider.reIssueRefreshToken(refreshToken);
                 if (newRefreshToken != null) {
-                    //                    response.setHeader(REFRESH_HEADER, TOKEN_AUTH_TYPE +
-                    // newRefreshToken);
                     Cookie refreshTokenCookie = jwtProvider.createCookie(newRefreshToken);
                     response.addCookie(refreshTokenCookie);
 
@@ -81,9 +78,20 @@ public class JwtFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String resolveToken(HttpServletRequest request, String headerName) {
+    private String resolveTokenFromHeader(HttpServletRequest request, String headerName) {
         String rawHeader = request.getHeader(headerName);
         return jwtProvider.getTokenFromHeader(rawHeader);
+    }
+
+    private String resolveTokenFromCookie(HttpServletRequest request) {
+        Cookie[] rc = request.getCookies();
+        String refreshtoken = null;
+        for (Cookie cookie : rc) {
+            if (cookie.getName().equals("refreshtoken")) {
+                refreshtoken = cookie.getValue();
+            }
+        }
+        return refreshtoken;
     }
 
     private boolean isIgnoredUrl(HttpServletRequest request) {

--- a/src/main/java/project/seatsence/global/config/security/JwtProvider.java
+++ b/src/main/java/project/seatsence/global/config/security/JwtProvider.java
@@ -125,7 +125,7 @@ public class JwtProvider implements InitializingBean {
      */
     private static Date createRefreshTokenExpiredDate() {
         Calendar issuedAt = Calendar.getInstance();
-//        issuedAt.add(Calendar.DAY_OF_MONTH, 2); // 2주
+        //        issuedAt.add(Calendar.DAY_OF_MONTH, 2); // 2주
         issuedAt.add(Calendar.MINUTE, 2);
 
         return issuedAt.getTime();
@@ -348,10 +348,11 @@ public class JwtProvider implements InitializingBean {
     public String issueRefreshToken(CustomUserDetailsDto user) {
         String refreshToken = generateRefreshToken(user);
         refreshTokenRepository
-                .findByEmail(user.getEmail()) //Todo : State가 ACTIVE인 것도 추가
+                .findByEmail(user.getEmail()) // Todo : State가 ACTIVE인 것도 추가
                 .ifPresentOrElse(
                         r -> {
-                            r.setRefreshToken(refreshToken); // Todo : DB의 값 refreshToken값으로 변경 필요하지않나?
+                            r.setRefreshToken(
+                                    refreshToken); // Todo : DB의 값 refreshToken값으로 변경 필요하지않나?
                         },
                         () -> {
                             RefreshToken newRefreshToken =

--- a/src/main/java/project/seatsence/global/config/security/JwtProvider.java
+++ b/src/main/java/project/seatsence/global/config/security/JwtProvider.java
@@ -113,7 +113,7 @@ public class JwtProvider implements InitializingBean {
      */
     private static Date createAccessTokenExpiredDate() {
         Calendar issuedAt = Calendar.getInstance();
-        issuedAt.add(Calendar.MINUTE, 1); // 30분
+        issuedAt.add(Calendar.MINUTE, 30); // 30분
 
         return issuedAt.getTime();
     }
@@ -125,8 +125,7 @@ public class JwtProvider implements InitializingBean {
      */
     private static Date createRefreshTokenExpiredDate() {
         Calendar issuedAt = Calendar.getInstance();
-        //        issuedAt.add(Calendar.DAY_OF_MONTH, 2); // 2주
-        issuedAt.add(Calendar.MINUTE, 2);
+        issuedAt.add(Calendar.DAY_OF_MONTH, 2); // 2주
 
         return issuedAt.getTime();
     }

--- a/src/main/java/project/seatsence/global/config/security/JwtProvider.java
+++ b/src/main/java/project/seatsence/global/config/security/JwtProvider.java
@@ -8,9 +8,12 @@ import static project.seatsence.src.auth.domain.TokenType.REFRESH_TOKEN;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.*;
 import javax.crypto.spec.SecretKeySpec;
+import javax.servlet.http.Cookie;
 import javax.xml.bind.DatatypeConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -355,5 +358,22 @@ public class JwtProvider implements InitializingBean {
                             refreshTokenRepository.save(newRefreshToken);
                         });
         return refreshToken;
+    }
+
+    /**
+     * Refresh Token을 위한 쿠키 생성
+     *
+     * @param user
+     * @return Refresh Token이 담긴 Cookie
+     */
+    public Cookie createCookie(CustomUserDetailsDto user) {
+        String cookieName = "refreshtoken";
+        String cookieValue = generateAccessToken(user);
+        var RefreshTokenCookie = URLEncoder.encode(cookieValue, StandardCharsets.UTF_8);
+        Cookie cookie = new Cookie(cookieName, RefreshTokenCookie);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(15 * 24 * 60 * 60); // 15일
+        return cookie;
     }
 }

--- a/src/main/java/project/seatsence/global/config/security/JwtProvider.java
+++ b/src/main/java/project/seatsence/global/config/security/JwtProvider.java
@@ -363,12 +363,12 @@ public class JwtProvider implements InitializingBean {
     /**
      * Refresh Token을 위한 쿠키 생성
      *
-     * @param user
+     * @param refreshToken
      * @return Refresh Token이 담긴 Cookie
      */
-    public Cookie createCookie(CustomUserDetailsDto user) {
+    public Cookie createCookie(String refreshToken) {
         String cookieName = "refreshtoken";
-        String cookieValue = generateAccessToken(user);
+        String cookieValue = refreshToken;
         var RefreshTokenCookie = URLEncoder.encode(cookieValue, StandardCharsets.UTF_8);
         Cookie cookie = new Cookie(cookieName, RefreshTokenCookie);
         cookie.setHttpOnly(true);

--- a/src/main/java/project/seatsence/global/config/security/JwtProvider.java
+++ b/src/main/java/project/seatsence/global/config/security/JwtProvider.java
@@ -113,7 +113,7 @@ public class JwtProvider implements InitializingBean {
      */
     private static Date createAccessTokenExpiredDate() {
         Calendar issuedAt = Calendar.getInstance();
-        issuedAt.add(Calendar.MINUTE, 30); // 30분
+        issuedAt.add(Calendar.MINUTE, 1); // 30분
 
         return issuedAt.getTime();
     }
@@ -125,7 +125,8 @@ public class JwtProvider implements InitializingBean {
      */
     private static Date createRefreshTokenExpiredDate() {
         Calendar issuedAt = Calendar.getInstance();
-        issuedAt.add(Calendar.DAY_OF_MONTH, 14); // 2주
+//        issuedAt.add(Calendar.DAY_OF_MONTH, 2); // 2주
+        issuedAt.add(Calendar.MINUTE, 2);
 
         return issuedAt.getTime();
     }

--- a/src/main/java/project/seatsence/global/config/security/JwtProvider.java
+++ b/src/main/java/project/seatsence/global/config/security/JwtProvider.java
@@ -348,10 +348,10 @@ public class JwtProvider implements InitializingBean {
     public String issueRefreshToken(CustomUserDetailsDto user) {
         String refreshToken = generateRefreshToken(user);
         refreshTokenRepository
-                .findByEmail(user.getEmail())
+                .findByEmail(user.getEmail()) //Todo : State가 ACTIVE인 것도 추가
                 .ifPresentOrElse(
                         r -> {
-                            r.setRefreshToken(refreshToken);
+                            r.setRefreshToken(refreshToken); // Todo : DB의 값 refreshToken값으로 변경 필요하지않나?
                         },
                         () -> {
                             RefreshToken newRefreshToken =

--- a/src/main/java/project/seatsence/src/user/api/UserApi.java
+++ b/src/main/java/project/seatsence/src/user/api/UserApi.java
@@ -2,7 +2,6 @@ package project.seatsence.src.user.api;
 
 import static project.seatsence.global.code.ResponseCode.USER_EMAIL_ALREADY_EXIST;
 import static project.seatsence.global.code.ResponseCode.USER_NICKNAME_ALREADY_EXIST;
-import static project.seatsence.global.constants.Constants.TOKEN_AUTH_TYPE;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import project.seatsence.global.config.security.JwtProvider;
 import project.seatsence.global.exceptions.BaseException;
 import project.seatsence.src.user.domain.User;
 import project.seatsence.src.user.dto.CustomUserDetailsDto;
@@ -31,7 +29,6 @@ import project.seatsence.src.user.service.UserService;
 public class UserApi {
 
     private final UserService userService;
-    private final JwtProvider jwtProvider;
 
     @Operation(summary = "이메일 검증 및 중복 확인")
     @PostMapping("/validate/email")
@@ -80,9 +77,8 @@ public class UserApi {
                         user.getState(),
                         user.getNickname(),
                         null);
-        String accessToken = TOKEN_AUTH_TYPE + jwtProvider.generateAccessToken(userDetailsDto);
-        String refreshToken =
-                jwtProvider.issueRefreshToken(userDetailsDto); // refresh token은 Bearer 없이
+        String accessToken = userService.issueAccessToken(userDetailsDto);
+        String refreshToken = userService.issueRefreshToken(userDetailsDto);
 
         userService.signIn(userSignInRequest, response, refreshToken, user);
 

--- a/src/main/java/project/seatsence/src/user/api/UserApi.java
+++ b/src/main/java/project/seatsence/src/user/api/UserApi.java
@@ -6,7 +6,6 @@ import static project.seatsence.global.constants.Constants.TOKEN_AUTH_TYPE;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -70,7 +69,8 @@ public class UserApi {
     @Operation(summary = "유저 로그인")
     @PostMapping("/sign-in")
     @Transactional
-    public UserSignInResponse userSignIn(@Valid @RequestBody UserSignInRequest userSignInRequest, HttpServletResponse response) {
+    public UserSignInResponse userSignIn(
+            @Valid @RequestBody UserSignInRequest userSignInRequest, HttpServletResponse response) {
 
         User user = userService.findUserByUserEmail(userSignInRequest.getEmail());
         CustomUserDetailsDto userDetailsDto =

--- a/src/main/java/project/seatsence/src/user/api/UserApi.java
+++ b/src/main/java/project/seatsence/src/user/api/UserApi.java
@@ -81,7 +81,7 @@ public class UserApi {
         String accessToken = TOKEN_AUTH_TYPE + jwtProvider.generateAccessToken(userDetailsDto);
         String refreshToken = TOKEN_AUTH_TYPE + jwtProvider.issueRefreshToken(userDetailsDto);
 
-        return new UserSignInResponse(accessToken, refreshToken);
+        return new UserSignInResponse(accessToken);
     }
 
     @Operation(summary = "일치하는 email의 user검색")

--- a/src/main/java/project/seatsence/src/user/api/UserApi.java
+++ b/src/main/java/project/seatsence/src/user/api/UserApi.java
@@ -81,7 +81,8 @@ public class UserApi {
                         user.getNickname(),
                         null);
         String accessToken = TOKEN_AUTH_TYPE + jwtProvider.generateAccessToken(userDetailsDto);
-        String refreshToken = TOKEN_AUTH_TYPE + jwtProvider.issueRefreshToken(userDetailsDto);
+        String refreshToken =
+                jwtProvider.issueRefreshToken(userDetailsDto); // refresh token은 Bearer 없이
 
         userService.signIn(userSignInRequest, response, refreshToken, user);
 

--- a/src/main/java/project/seatsence/src/user/api/UserApi.java
+++ b/src/main/java/project/seatsence/src/user/api/UserApi.java
@@ -6,6 +6,8 @@ import static project.seatsence.global.constants.Constants.TOKEN_AUTH_TYPE;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,7 +70,7 @@ public class UserApi {
     @Operation(summary = "유저 로그인")
     @PostMapping("/sign-in")
     @Transactional
-    public UserSignInResponse userSignIn(@Valid @RequestBody UserSignInRequest userSignInRequest) {
+    public UserSignInResponse userSignIn(@Valid @RequestBody UserSignInRequest userSignInRequest, HttpServletResponse response) {
 
         User user = userService.findUserByUserEmail(userSignInRequest.getEmail());
         CustomUserDetailsDto userDetailsDto =
@@ -80,6 +82,8 @@ public class UserApi {
                         null);
         String accessToken = TOKEN_AUTH_TYPE + jwtProvider.generateAccessToken(userDetailsDto);
         String refreshToken = TOKEN_AUTH_TYPE + jwtProvider.issueRefreshToken(userDetailsDto);
+
+        userService.signIn(userSignInRequest, response, refreshToken, user);
 
         return new UserSignInResponse(accessToken);
     }

--- a/src/main/java/project/seatsence/src/user/dto/response/UserSignInResponse.java
+++ b/src/main/java/project/seatsence/src/user/dto/response/UserSignInResponse.java
@@ -9,5 +9,4 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserSignInResponse {
     private String accessToken;
-    private String refreshToken;
 }

--- a/src/main/java/project/seatsence/src/user/service/UserService.java
+++ b/src/main/java/project/seatsence/src/user/service/UserService.java
@@ -2,10 +2,13 @@ package project.seatsence.src.user.service;
 
 import static project.seatsence.global.code.ResponseCode.USER_NOT_FOUND;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import project.seatsence.global.config.security.JwtProvider;
 import project.seatsence.global.entity.BaseTimeAndStateEntity;
 import project.seatsence.global.exceptions.BaseException;
 import project.seatsence.src.user.dao.UserRepository;
@@ -15,13 +18,12 @@ import project.seatsence.src.user.dto.request.UserSignInRequest;
 import project.seatsence.src.user.dto.request.UserSignUpRequest;
 import project.seatsence.src.user.dto.response.UserSignUpResponse;
 
-import javax.servlet.http.HttpServletResponse;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class UserService {
     private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
 
     private final PasswordEncoder passwordEncoder;
 
@@ -57,12 +59,17 @@ public class UserService {
         return new UserSignUpResponse("회원가입이 완료되었습니다.", user.getId());
     }
 
-
     @Transactional(readOnly = true)
-    public void signIn(UserSignInRequest userSignInRequest, HttpServletResponse response, String refreshToken, User user) {
+    public void signIn(
+            UserSignInRequest userSignInRequest,
+            HttpServletResponse response,
+            String refreshToken,
+            User user) {
         String password = userSignInRequest.getPassword();
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new BaseException(USER_NOT_FOUND);
         }
+        Cookie cookie = jwtProvider.createCookie(refreshToken);
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/project/seatsence/src/user/service/UserService.java
+++ b/src/main/java/project/seatsence/src/user/service/UserService.java
@@ -1,6 +1,7 @@
 package project.seatsence.src.user.service;
 
 import static project.seatsence.global.code.ResponseCode.USER_NOT_FOUND;
+import static project.seatsence.global.constants.Constants.TOKEN_AUTH_TYPE;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
@@ -14,6 +15,7 @@ import project.seatsence.global.exceptions.BaseException;
 import project.seatsence.src.user.dao.UserRepository;
 import project.seatsence.src.user.domain.User;
 import project.seatsence.src.user.domain.UserRole;
+import project.seatsence.src.user.dto.CustomUserDetailsDto;
 import project.seatsence.src.user.dto.request.UserSignInRequest;
 import project.seatsence.src.user.dto.request.UserSignUpRequest;
 import project.seatsence.src.user.dto.response.UserSignUpResponse;
@@ -71,5 +73,13 @@ public class UserService {
         }
         Cookie cookie = jwtProvider.createCookie(refreshToken);
         response.addCookie(cookie);
+    }
+
+    public String issueAccessToken(CustomUserDetailsDto userDetailsDto) {
+        return TOKEN_AUTH_TYPE + jwtProvider.generateAccessToken(userDetailsDto);
+    }
+
+    public String issueRefreshToken(CustomUserDetailsDto userDetailsDto) {
+        return jwtProvider.issueRefreshToken(userDetailsDto); // refresh token은 Bearer 없이
     }
 }

--- a/src/main/java/project/seatsence/src/user/service/UserService.java
+++ b/src/main/java/project/seatsence/src/user/service/UserService.java
@@ -11,8 +11,11 @@ import project.seatsence.global.exceptions.BaseException;
 import project.seatsence.src.user.dao.UserRepository;
 import project.seatsence.src.user.domain.User;
 import project.seatsence.src.user.domain.UserRole;
+import project.seatsence.src.user.dto.request.UserSignInRequest;
 import project.seatsence.src.user.dto.request.UserSignUpRequest;
 import project.seatsence.src.user.dto.response.UserSignUpResponse;
+
+import javax.servlet.http.HttpServletResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -52,5 +55,14 @@ public class UserService {
         userRepository.save(user);
 
         return new UserSignUpResponse("회원가입이 완료되었습니다.", user.getId());
+    }
+
+
+    @Transactional(readOnly = true)
+    public void signIn(UserSignInRequest userSignInRequest, HttpServletResponse response, String refreshToken, User user) {
+        String password = userSignInRequest.getPassword();
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BaseException(USER_NOT_FOUND);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Close #85 

<br>

## Changes 
- Refresh Token (재)발급시, Cookie에 담아 보내기
- Access Token만료시, Cookie에 담겨있는 Refresh Token을 확인
- user 로그인 비밀번호 검증 로직 추가

<br>

## To Reviewers
- 

<br>