### PR TITLE
관리자의 예약 관리를 위해, ReservationStatus enum 생성 및 예약시 기본값으로 PENDING이 들어가도록 수정

### DIFF
--- a/src/main/java/project/seatsence/global/constants/Constants.java
+++ b/src/main/java/project/seatsence/global/constants/Constants.java
@@ -12,6 +12,6 @@ public class Constants {
 
     public static final int RESERVATION_OR_USE_TIME_UNIT = 30; // 30분 단위
 
-    public static final int CAN_HOUR_OF_SAME_DAY_RESERVATION_START_TIME_FROM_THE_CURRENT_TIME =
+    public static final int MIN_HOURS_FOR_SAME_DAY_RESERVATION =
             3; // 당일 예약 가능한 시작 시간 = 현시간 기준 '3'시간 이후
 }

--- a/src/main/java/project/seatsence/src/reservation/api/ReservationApi.java
+++ b/src/main/java/project/seatsence/src/reservation/api/ReservationApi.java
@@ -1,6 +1,7 @@
 package project.seatsence.src.reservation.api;
 
 import static project.seatsence.global.code.ResponseCode.*;
+import static project.seatsence.src.reservation.domain.ReservationStatus.*;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -68,6 +69,7 @@ public class ReservationApi {
                                 seatReservationRequest.getReservationStartDateAndTime())
                         .reservationEndDateAndTime(
                                 seatReservationRequest.getReservationEndDateAndTime())
+                        .reservationStatus(PENDING)
                         .build();
 
         reservationService.saveReservation(reservation);
@@ -111,6 +113,7 @@ public class ReservationApi {
                                 spaceReservationRequest.getReservationStartDateAndTime())
                         .reservationEndDateAndTime(
                                 spaceReservationRequest.getReservationEndDateAndTime())
+                        .reservationStatus(PENDING)
                         .build();
 
         reservationService.saveReservation(reservation);

--- a/src/main/java/project/seatsence/src/reservation/domain/Reservation.java
+++ b/src/main/java/project/seatsence/src/reservation/domain/Reservation.java
@@ -45,11 +45,13 @@ public class Reservation extends BaseEntity {
             StoreSpace storeSpace,
             User user,
             LocalDateTime reservationStartDateAndTime,
-            LocalDateTime reservationEndDateAndTime) {
+            LocalDateTime reservationEndDateAndTime,
+            ReservationStatus reservationStatus) {
         this.storeChair = storeChair;
         this.storeSpace = storeSpace;
         this.user = user;
         this.reservationStartDateAndTime = reservationStartDateAndTime;
         this.reservationEndDateAndTime = reservationEndDateAndTime;
+        this.reservationStatus = reservationStatus;
     }
 }

--- a/src/main/java/project/seatsence/src/reservation/domain/Reservation.java
+++ b/src/main/java/project/seatsence/src/reservation/domain/Reservation.java
@@ -37,6 +37,8 @@ public class Reservation extends BaseEntity {
     @NotNull private LocalDateTime reservationStartDateAndTime;
     @NotNull private LocalDateTime reservationEndDateAndTime;
 
+    @NotNull private ReservationStatus reservationStatus;
+
     @Builder
     public Reservation(
             StoreChair storeChair,

--- a/src/main/java/project/seatsence/src/reservation/domain/ReservationStatus.java
+++ b/src/main/java/project/seatsence/src/reservation/domain/ReservationStatus.java
@@ -1,0 +1,17 @@
+package project.seatsence.src.reservation.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReservationStatus {
+    PENDING("PENDING", "대기"),
+    APPROVED("APPROVED", "승인"),
+    REJECTED("REJECTED", "거절");
+
+    private String value;
+
+    @JsonValue private String kr;
+}

--- a/src/main/java/project/seatsence/src/reservation/domain/ReservationStatus.java
+++ b/src/main/java/project/seatsence/src/reservation/domain/ReservationStatus.java
@@ -8,8 +8,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ReservationStatus {
     PENDING("PENDING", "대기"),
-    APPROVED("APPROVED", "승인"),
-    REJECTED("REJECTED", "거절");
+    CANCELED("CANCELED", "취소"), // 유저 직접 취소
+    APPROVED("APPROVED", "승인"), // 관리자 승인
+    REJECTED("REJECTED", "거절"); // 관리자 거절
 
     private String value;
 

--- a/src/main/java/project/seatsence/src/reservation/service/ReservationService.java
+++ b/src/main/java/project/seatsence/src/reservation/service/ReservationService.java
@@ -1,6 +1,6 @@
 package project.seatsence.src.reservation.service;
 
-import static project.seatsence.global.constants.Constants.CAN_HOUR_OF_SAME_DAY_RESERVATION_START_TIME_FROM_THE_CURRENT_TIME;
+import static project.seatsence.global.constants.Constants.MIN_HOURS_FOR_SAME_DAY_RESERVATION;
 import static project.seatsence.global.constants.Constants.RESERVATION_OR_USE_TIME_UNIT;
 
 import java.time.LocalDateTime;
@@ -60,7 +60,7 @@ public class ReservationService {
         if (now.getMinute() == 0) {
             if (!(inputDateTime.getHour()
                     >= now.getHour()
-                            + CAN_HOUR_OF_SAME_DAY_RESERVATION_START_TIME_FROM_THE_CURRENT_TIME)) {
+                            + MIN_HOURS_FOR_SAME_DAY_RESERVATION)) {
                 result = false;
             }
         }
@@ -68,7 +68,7 @@ public class ReservationService {
         if (now.getMinute() >= RESERVATION_OR_USE_TIME_UNIT) { // 30분 이상
             if (!(inputDateTime.getHour()
                     >= now.getHour()
-                            + (CAN_HOUR_OF_SAME_DAY_RESERVATION_START_TIME_FROM_THE_CURRENT_TIME
+                            + (MIN_HOURS_FOR_SAME_DAY_RESERVATION
                                     + 1))) {
                 result = false;
             }
@@ -77,14 +77,14 @@ public class ReservationService {
         if (now.getMinute() < RESERVATION_OR_USE_TIME_UNIT) { // 30분 미만
             if (inputDateTime.getHour()
                     == now.getHour()
-                            + CAN_HOUR_OF_SAME_DAY_RESERVATION_START_TIME_FROM_THE_CURRENT_TIME) {
+                            + MIN_HOURS_FOR_SAME_DAY_RESERVATION) {
                 if (inputDateTime.getMinute() != RESERVATION_OR_USE_TIME_UNIT) {
                     result = false;
                 }
             }
             if (!(inputDateTime.getHour()
                     > now.getHour()
-                            + CAN_HOUR_OF_SAME_DAY_RESERVATION_START_TIME_FROM_THE_CURRENT_TIME)) {
+                            + MIN_HOURS_FOR_SAME_DAY_RESERVATION)) {
                 result = false;
             }
         }


### PR DESCRIPTION
## Summary
- Closes #112 

<br>

## Changes 
- ReservationStatus enum 생성
- 유저가 예약시, 기본값으로 PENDING이 들어가도록 수정
- 당일 예약시 예약 시작시간으로 가능한 최소 시간 상수명 수정 

<br>

## To Reviewers
- 

<br>