### PR TITLE
CORS 해결을 위해 Security 설정 일부 수정 및 노출 Cookie명 변경 

### DIFF
--- a/src/main/java/project/seatsence/global/config/security/CorsConfig.java
+++ b/src/main/java/project/seatsence/global/config/security/CorsConfig.java
@@ -2,6 +2,7 @@ package project.seatsence.global.config.security;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -11,8 +12,13 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "http://localhost:8080")
-                .allowedMethods("*")
+                .allowedOrigins("http://localhost:3000", "http://localhost:8080") // Todo : domain 추가
+                .allowedMethods(HttpMethod.GET.name(),
+                        HttpMethod.PATCH.name(),
+                        HttpMethod.POST.name(),
+                        HttpMethod.PUT.name(),
+                        HttpMethod.DELETE.name(),
+                        HttpMethod.OPTIONS.name())
                 .exposedHeaders("refreshToken")
                 .allowCredentials(true); // 쿠키 인증 요청 허용
     }

--- a/src/main/java/project/seatsence/global/config/security/CorsConfig.java
+++ b/src/main/java/project/seatsence/global/config/security/CorsConfig.java
@@ -12,14 +12,16 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "http://localhost:8080") // Todo : domain 추가
-                .allowedMethods(HttpMethod.GET.name(),
+                .allowedOrigins(
+                        "http://localhost:3000", "http://localhost:8080") // Todo : domain 추가
+                .allowedMethods(
+                        HttpMethod.GET.name(),
                         HttpMethod.PATCH.name(),
                         HttpMethod.POST.name(),
                         HttpMethod.PUT.name(),
                         HttpMethod.DELETE.name(),
                         HttpMethod.OPTIONS.name())
-                .exposedHeaders("refreshToken")
+                .exposedHeaders("Set-Cookie")
                 .allowCredentials(true); // 쿠키 인증 요청 허용
     }
 }

--- a/src/main/java/project/seatsence/global/config/security/JwtProvider.java
+++ b/src/main/java/project/seatsence/global/config/security/JwtProvider.java
@@ -373,7 +373,7 @@ public class JwtProvider implements InitializingBean {
         String cookieValue = refreshToken;
         var RefreshTokenCookie = URLEncoder.encode(cookieValue, StandardCharsets.UTF_8);
         Cookie cookie = new Cookie(cookieName, RefreshTokenCookie);
-        cookie.setHttpOnly(true);
+        cookie.setHttpOnly(true); // Todo : SSL 적용 후, Secure 설정 추가
         cookie.setPath("/");
         cookie.setMaxAge(15 * 24 * 60 * 60); // 15일
         return cookie;

--- a/src/main/java/project/seatsence/global/config/security/SpringSecurityConfig.java
+++ b/src/main/java/project/seatsence/global/config/security/SpringSecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsUtils;
 import project.seatsence.global.config.filter.JwtFilter;
 import project.seatsence.src.user.service.UserDetailsServiceImpl;
 
@@ -41,6 +42,8 @@ public class SpringSecurityConfig {
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeRequests()
                 .mvcMatchers(SwaggerPatterns)
+                .permitAll()
+                .requestMatchers(CorsUtils::isPreFlightRequest)
                 .permitAll()
                 .antMatchers("/v1/users/validate/**", "/v1/users/sign-in", "/v1/users/sign-up")
                 .permitAll()


### PR DESCRIPTION
## Summary
- Closes #128 

<br>

## Changes 
- CORS 해결위해 SecurityFilterChain에서 PreFlightRequest 전체 허용 설정 추가
- CORS 해결 및 보안을 위해 CorsRegistry의 allowedMethods값을 "*"에서 각각 메소드명으로 수정
- 화면에서 쿠키값 읽을 수 있도록 하기위해 CorsRegistry의 exposedHeaders명 변경

<br>

## To Reviewers
- 

<br>