### PR TITLE
기획 변경에 따른, 유저 예약 취소 API쪽 로직 통합 

### DIFF
--- a/src/main/java/project/seatsence/global/config/security/JwtProvider.java
+++ b/src/main/java/project/seatsence/global/config/security/JwtProvider.java
@@ -111,7 +111,8 @@ public class JwtProvider implements InitializingBean {
      */
     private static Date createAccessTokenExpiredDate() {
         Calendar issuedAt = Calendar.getInstance();
-        issuedAt.add(Calendar.MINUTE, 30); // 30분
+        //        issuedAt.add(Calendar.MINUTE, 30); // 30분
+        issuedAt.add(Calendar.MINUTE, 5); // test용 // Todo : 테스트 끝나면, 실제 만료시간으로 바꾸기
 
         return issuedAt.getTime();
     }
@@ -123,7 +124,8 @@ public class JwtProvider implements InitializingBean {
      */
     private static Date createRefreshTokenExpiredDate() {
         Calendar issuedAt = Calendar.getInstance();
-        issuedAt.add(Calendar.DAY_OF_MONTH, 2); // 2주
+        //        issuedAt.add(Calendar.DAY_OF_MONTH, 2); // 2주
+        issuedAt.add(Calendar.MINUTE, 30); // test용 // Todo : 테스트 끝나면, 실제 만료시간으로 바꾸기
 
         return issuedAt.getTime();
     }

--- a/src/main/java/project/seatsence/src/reservation/api/UserReservationApi.java
+++ b/src/main/java/project/seatsence/src/reservation/api/UserReservationApi.java
@@ -194,25 +194,14 @@ public class UserReservationApi {
         return userReservationService.getUserReservationList(userId, reservationStatus, pageable);
     }
 
-    @Operation(summary = "유저 좌석 예약 취소", description = "유저가 예약했던 특정 좌석의 예약을 취소합니다.")
-    @DeleteMapping("/seat/{reservation-id}")
-    public void cancelSeatReservation(
+    @Operation(summary = "유저 예약 취소", description = "유저가 예약했던 좌석 혹은 스페이스의 예약을 취소합니다.")
+    @DeleteMapping("/{reservation-id}")
+    public void cancelReservation(
             @Parameter(name = "예약 식별자", in = ParameterIn.PATH, example = "1")
                     @PathVariable("reservation-id")
                     Long reservationId) {
         Reservation reservation = reservationService.findById(reservationId); // Todo : Refactoring
 
-        userReservationService.cancelSeatReservation(reservation);
-    }
-
-    @Operation(summary = "유저 스페이스 예약 취소", description = "유저가 예약했던 특정 스페이스의 예약을 취소합니다.")
-    @DeleteMapping("/space/{reservation-id}")
-    public void cancelSpaceReservation(
-            @Parameter(name = "예약 식별자", in = ParameterIn.PATH, example = "2")
-                    @PathVariable("reservation-id")
-                    Long reservationId) {
-        Reservation reservation = reservationService.findById(reservationId); // Todo : Refactoring
-
-        userReservationService.cancelSpaceReservation(reservation);
+        userReservationService.cancelReservation(reservation);
     }
 }

--- a/src/main/java/project/seatsence/src/reservation/service/UserReservationService.java
+++ b/src/main/java/project/seatsence/src/reservation/service/UserReservationService.java
@@ -207,13 +207,7 @@ public class UserReservationService {
                         .map(UserReservationListResponse::from));
     }
 
-    public void cancelSeatReservation(Reservation reservation) {
-        reservationService.checkValidationToModifyReservationStatus(reservation);
-
-        reservation.setReservationStatus(CANCELED);
-    }
-
-    public void cancelSpaceReservation(Reservation reservation) {
+    public void cancelReservation(Reservation reservation) {
         reservationService.checkValidationToModifyReservationStatus(reservation);
 
         reservation.setReservationStatus(CANCELED);

--- a/src/main/java/project/seatsence/src/reservation/service/UserReservationService.java
+++ b/src/main/java/project/seatsence/src/reservation/service/UserReservationService.java
@@ -217,7 +217,5 @@ public class UserReservationService {
         reservationService.checkValidationToModifyReservationStatus(reservation);
 
         reservation.setReservationStatus(CANCELED);
-
-        // Todo : 참석자도 함께 취소처리
     }
 }


### PR DESCRIPTION
## Summary
- Closes #143 

<br>

## Changes 
- Test를 위한 토큰 만료시간 변경 (액세스 = 5분 / 리프레쉬 = 30분)
- 기획 변경에 따라, 유저 좌석 예약 취소 API와 유저 스페이스 예약 취소 API를 하나의 "유저 예약 취소 API"로 통합

<br>

## To Reviewers
- 

<br>