### PR TITLE
storeSpace명이 조회되지않는 NPE 해결 및 필드와 데이터에서 예약된 정보와 관리 정보의 명확한 구분을 위해 필드(컬럼)명 수정

### DIFF
--- a/src/main/java/project/seatsence/src/user/service/UserService.java
+++ b/src/main/java/project/seatsence/src/user/service/UserService.java
@@ -100,7 +100,7 @@ public class UserService {
         return jwtProvider.issueRefreshToken(userDetailsDto); // refresh token은 Bearer 없이
     }
 
-    public User findById(Long id) {
+    public User findByIdAndState(Long id) {
         return userRepository
                 .findByIdAndState(id, ACTIVE)
                 .orElseThrow(() -> new BaseException(USER_NOT_FOUND));

--- a/src/main/java/project/seatsence/src/utilization/api/reservation/AdminReservationApi.java
+++ b/src/main/java/project/seatsence/src/utilization/api/reservation/AdminReservationApi.java
@@ -41,7 +41,7 @@ public class AdminReservationApi {
     @GetMapping("/{store-id}/all-list")
     public ReservationListResponse entireReservationList(@PathVariable("store-id") Long storeId) {
 
-        List<Reservation> reservations = adminReservationService.getAllReservation(storeId);
+        List<Reservation> reservations = adminReservationService.getAllReservationAndState(storeId);
         List<ReservationListResponse.ReservationResponse> reservationResponseList =
                 reservations.stream()
                         .map(ReservationMapper::toReservationResponse)

--- a/src/main/java/project/seatsence/src/utilization/api/reservation/UserReservationApi.java
+++ b/src/main/java/project/seatsence/src/utilization/api/reservation/UserReservationApi.java
@@ -95,7 +95,7 @@ public class UserReservationApi {
             }
         }
 
-        User userFound = userService.findById(seatReservationRequest.getUserId());
+        User userFound = userService.findByIdAndState(seatReservationRequest.getUserId());
 
         Reservation reservation =
                 Reservation.builder()
@@ -162,7 +162,7 @@ public class UserReservationApi {
             }
         }
 
-        User userFound = userService.findById(spaceReservationRequest.getUserId());
+        User userFound = userService.findByIdAndState(spaceReservationRequest.getUserId());
 
         Reservation reservation =
                 Reservation.builder()
@@ -201,7 +201,7 @@ public class UserReservationApi {
             @Parameter(name = "예약 식별자", in = ParameterIn.PATH, example = "1")
                     @PathVariable("reservation-id")
                     Long reservationId) {
-        Reservation reservation = reservationService.findById(reservationId); // Todo : Refactoring
+        Reservation reservation = reservationService.findByIdAndState(reservationId); // Todo : Refactoring
 
         userReservationService.cancelReservation(reservation);
     }

--- a/src/main/java/project/seatsence/src/utilization/dao/reservation/ReservationRepository.java
+++ b/src/main/java/project/seatsence/src/utilization/dao/reservation/ReservationRepository.java
@@ -1,6 +1,8 @@
 package project.seatsence.src.utilization.dao.reservation;
 
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,11 +21,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             findAllByUserAndReservationStatusAndStateOrderByReservationStartDateAndTimeDesc(
                     User user, ReservationStatus reservationStatus, State state, Pageable pageable);
 
-    Reservation findByStoreChairAndUserAndState(StoreChair storeChair, User user, State state);
+    Reservation findByReservedStoreChairAndUserAndState(StoreChair storeChair, User user, State state);
 
-    Reservation findByIdAndState(Long id, State state);
+    Optional<Reservation> findByIdAndState(Long id, State state);
 
-    List<Reservation> findAllByStoreId(Long storeId);
+    List<Reservation> findAllByStoreIdAndState(Long storeId, State state);
 
     List<Reservation> findAllByStoreIdAndReservationStatus(
             Long storeId, ReservationStatus reservationStatus);

--- a/src/main/java/project/seatsence/src/utilization/domain/reservation/Reservation.java
+++ b/src/main/java/project/seatsence/src/utilization/domain/reservation/Reservation.java
@@ -27,13 +27,13 @@ public class Reservation extends BaseEntity {
 
     @Nullable
     @ManyToOne
-    @JoinColumn(name = "store_space_id")
-    private StoreSpace storeSpace;
+    @JoinColumn(name = "reserved_store_space_id")
+    private StoreSpace reservedStoreSpace;
 
     @Nullable
     @ManyToOne
-    @JoinColumn(name = "store_chair_id")
-    private StoreChair storeChair;
+    @JoinColumn(name = "reserved_store_chair_id")
+    private StoreChair reservedStoreChair;
 
     @NotNull
     @ManyToOne
@@ -57,8 +57,8 @@ public class Reservation extends BaseEntity {
             LocalDateTime reservationEndDateAndTime,
             ReservationStatus reservationStatus) {
         this.store = store;
-        this.storeSpace = storeSpace;
-        this.storeChair = storeChair;
+        this.reservedStoreSpace = storeSpace;
+        this.reservedStoreChair = storeChair;
         this.user = user;
         this.reservationStartDateAndTime = reservationStartDateAndTime;
         this.reservationEndDateAndTime = reservationEndDateAndTime;

--- a/src/main/java/project/seatsence/src/utilization/dto/reservation/ReservationMapper.java
+++ b/src/main/java/project/seatsence/src/utilization/dto/reservation/ReservationMapper.java
@@ -11,12 +11,12 @@ public class ReservationMapper {
                 .name(reservation.getUser().getName())
                 .reservationStatus(reservation.getReservationStatus())
                 .storeSpaceId(
-                        reservation.getStoreSpace() != null
-                                ? reservation.getStoreSpace().getId()
+                        reservation.getReservedStoreSpace() != null
+                                ? reservation.getReservedStoreSpace().getId()
                                 : null)
                 .storeChairId(
-                        reservation.getStoreChair() != null
-                                ? reservation.getStoreChair().getId()
+                        reservation.getReservedStoreChair() != null
+                                ? reservation.getReservedStoreChair().getId()
                                 : null)
                 .reservationStartDateAndTime(reservation.getReservationStartDateAndTime())
                 .reservationEndDateAndTime(reservation.getReservationEndDateAndTime())

--- a/src/main/java/project/seatsence/src/utilization/dto/reservation/response/UserReservationListResponse.java
+++ b/src/main/java/project/seatsence/src/utilization/dto/reservation/response/UserReservationListResponse.java
@@ -37,20 +37,23 @@ public class UserReservationListResponse {
     public static UserReservationListResponse from(Reservation reservation) {
         String reservationUnitReservedByUser = null;
         String reservedPlace = null;
+        String storeSpaceName = null;
 
         if (reservation.getStoreChair() == null) {
             reservationUnitReservedByUser = "스페이스";
             reservedPlace = reservation.getStoreSpace().getName();
+            storeSpaceName = reservation.getStoreSpace().getName();
         } else if (reservation.getStoreSpace() == null) {
             reservationUnitReservedByUser = "좌석";
             reservedPlace = reservation.getStoreChair().getManageId();
+            storeSpaceName = reservation.getStoreChair().getStoreSpace().getName();
         }
 
         return UserReservationListResponse.builder()
                 .reservationId(reservation.getId())
                 .storeName(reservation.getStore().getName())
                 .reservationUnitReservedByUser(reservationUnitReservedByUser)
-                .storeSpaceName(reservation.getStoreSpace().getName())
+                .storeSpaceName(storeSpaceName)
                 .reservedPlace(reservedPlace)
                 .reservationStartDateAndTime(reservation.getReservationStartDateAndTime())
                 .reservationEndDateAndTime(reservation.getReservationEndDateAndTime())

--- a/src/main/java/project/seatsence/src/utilization/dto/reservation/response/UserReservationListResponse.java
+++ b/src/main/java/project/seatsence/src/utilization/dto/reservation/response/UserReservationListResponse.java
@@ -39,14 +39,14 @@ public class UserReservationListResponse {
         String reservedPlace = null;
         String storeSpaceName = null;
 
-        if (reservation.getStoreChair() == null) {
+        if (reservation.getReservedStoreChair() == null) {
             reservationUnitReservedByUser = "스페이스";
-            reservedPlace = reservation.getStoreSpace().getName();
-            storeSpaceName = reservation.getStoreSpace().getName();
-        } else if (reservation.getStoreSpace() == null) {
+            reservedPlace = reservation.getReservedStoreSpace().getName();
+            storeSpaceName = reservedPlace;
+        } else if (reservation.getReservedStoreSpace() == null) {
             reservationUnitReservedByUser = "좌석";
-            reservedPlace = reservation.getStoreChair().getManageId();
-            storeSpaceName = reservation.getStoreChair().getStoreSpace().getName();
+            reservedPlace = reservation.getReservedStoreChair().getManageId();
+            storeSpaceName = reservation.getReservedStoreChair().getStoreSpace().getName();
         }
 
         return UserReservationListResponse.builder()

--- a/src/main/java/project/seatsence/src/utilization/service/reservation/AdminReservationService.java
+++ b/src/main/java/project/seatsence/src/utilization/service/reservation/AdminReservationService.java
@@ -1,11 +1,13 @@
 package project.seatsence.src.utilization.service.reservation;
 
 import static project.seatsence.global.code.ResponseCode.RESERVATION_NOT_FOUND;
+import static project.seatsence.global.entity.BaseTimeAndStateEntity.State.*;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import project.seatsence.global.exceptions.BaseException;
 import project.seatsence.src.utilization.dao.reservation.ReservationRepository;
 import project.seatsence.src.utilization.domain.reservation.Reservation;
@@ -20,17 +22,17 @@ public class AdminReservationService {
     private final ReservationService reservationService;
 
     public void reservationApprove(Long reservationId) {
-        Reservation reservation = reservationService.findById(reservationId);
+        Reservation reservation = reservationService.findByIdAndState(reservationId);
         reservation.setReservationStatus(ReservationStatus.APPROVED);
     }
 
     public void reservationReject(Long reservationId) {
-        Reservation reservation = reservationService.findById(reservationId);
+        Reservation reservation = reservationService.findByIdAndState(reservationId);
         reservation.setReservationStatus(ReservationStatus.REJECTED);
     }
 
-    public List<Reservation> getAllReservation(Long storeId) {
-        List<Reservation> reservationList = reservationRepository.findAllByStoreId(storeId);
+    public List<Reservation> getAllReservationAndState(Long storeId) {
+        List<Reservation> reservationList = reservationRepository.findAllByStoreIdAndState(storeId, ACTIVE);
         if (reservationList == null || reservationList.isEmpty())
             throw new BaseException(RESERVATION_NOT_FOUND);
         return reservationList;

--- a/src/main/java/project/seatsence/src/utilization/service/reservation/ReservationService.java
+++ b/src/main/java/project/seatsence/src/utilization/service/reservation/ReservationService.java
@@ -2,11 +2,13 @@ package project.seatsence.src.utilization.service.reservation;
 
 import static project.seatsence.global.code.ResponseCode.*;
 import static project.seatsence.src.utilization.domain.reservation.ReservationStatus.PENDING;
+import static project.seatsence.global.entity.BaseTimeAndStateEntity.State.*;
 
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import project.seatsence.global.entity.BaseTimeAndStateEntity;
 import project.seatsence.global.exceptions.BaseException;
 import project.seatsence.src.utilization.dao.reservation.ReservationRepository;
 import project.seatsence.src.utilization.domain.reservation.Reservation;
@@ -18,9 +20,9 @@ public class ReservationService {
 
     private final ReservationRepository reservationRepository;
 
-    public Reservation findById(Long id) {
+    public Reservation findByIdAndState(Long id) {
         return reservationRepository
-                .findById(id)
+                .findByIdAndState(id, ACTIVE)
                 .orElseThrow(() -> new BaseException(RESERVATION_NOT_FOUND));
     }
 


### PR DESCRIPTION
## Summary
- Close #157 

<br>

## Changes 
- 유저 예약 현황 조회API에서, storeSpace명이 조회되지않는 NPE 해결
- 필드 및 데이터에서 예약된 정보와 관리정보의 명확한 구분을 위해 필드명과 컬럼명 수정
- 명명규칙에 맞게 일부 Service단에 "AndState" 추가

<br>

## To Reviewers
- 

<br>