### PR TITLE
유저 예약 현황 조회 API에서 예약 상태가 '대기'인 데이터의 예약 끝 일정이 현 시간을 지났을 경우 '거절'로 바뀌도록 로직 추가 및 Reservation쪽 Service에서 Repository를 직접 사용하지 않도록 리팩토링

### DIFF
--- a/src/main/java/project/seatsence/src/utilization/api/reservation/UserReservationApi.java
+++ b/src/main/java/project/seatsence/src/utilization/api/reservation/UserReservationApi.java
@@ -116,7 +116,7 @@ public class UserReservationApi {
                         .reservationStatus(PENDING)
                         .build();
 
-        userReservationService.saveReservation(reservation);
+        reservationService.save(reservation);
     }
 
     @Operation(summary = "유저 스페이스 예약", description = "유저가 예약하고싶은 날짜의 특정 스페이스를 예약합니다.")
@@ -184,7 +184,7 @@ public class UserReservationApi {
                         .reservationStatus(PENDING)
                         .build();
 
-        userReservationService.saveReservation(reservation);
+        reservationService.save(reservation);
     }
 
     @Operation(

--- a/src/main/java/project/seatsence/src/utilization/api/reservation/UserReservationApi.java
+++ b/src/main/java/project/seatsence/src/utilization/api/reservation/UserReservationApi.java
@@ -27,6 +27,7 @@ import project.seatsence.src.store.service.StoreSpaceService;
 import project.seatsence.src.user.domain.User;
 import project.seatsence.src.user.service.UserService;
 import project.seatsence.src.utilization.domain.reservation.Reservation;
+import project.seatsence.src.utilization.domain.reservation.ReservationStatus;
 import project.seatsence.src.utilization.dto.reservation.request.AllReservationsForSeatAndDateRequest;
 import project.seatsence.src.utilization.dto.reservation.request.ChairReservationRequest;
 import project.seatsence.src.utilization.dto.reservation.request.SpaceReservationRequest;
@@ -202,7 +203,7 @@ public class UserReservationApi {
             @ParameterObject @PageableDefault(page = 1, size = 15) Pageable pageable) {
         String userEmail = JwtProvider.getUserEmailFromToken(token);
         return userReservationService.getUserReservationList(
-                userEmail, reservationStatus, pageable);
+                userEmail, ReservationStatus.valueOfKr(reservationStatus), pageable);
     }
 
     @Operation(summary = "유저 예약 취소", description = "유저가 예약했던 좌석 혹은 스페이스의 예약을 취소합니다.")

--- a/src/main/java/project/seatsence/src/utilization/dao/reservation/ReservationRepository.java
+++ b/src/main/java/project/seatsence/src/utilization/dao/reservation/ReservationRepository.java
@@ -21,6 +21,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     Slice<Reservation> findAllByUserAndReservationStatusAndStateOrderByStartScheduleDesc(
             User user, ReservationStatus reservationStatus, State state, Pageable pageable);
 
+    List<Reservation> findAllByUserAndReservationStatusAndState(
+            User user, ReservationStatus reservationStatus, State state);
+
     Reservation findByReservedStoreChairAndUserAndState(
             StoreChair storeChair, User user, State state);
 

--- a/src/main/java/project/seatsence/src/utilization/dao/reservation/ReservationRepository.java
+++ b/src/main/java/project/seatsence/src/utilization/dao/reservation/ReservationRepository.java
@@ -16,23 +16,18 @@ import project.seatsence.src.utilization.domain.reservation.ReservationStatus;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    /** Reservation (Common (User + Admin)) */
     Reservation save(Reservation reservation);
 
+    Optional<Reservation> findByIdAndState(Long id, State state);
+
+    /** User Reservation */
     Slice<Reservation> findAllByUserAndReservationStatusAndStateOrderByStartScheduleDesc(
             User user, ReservationStatus reservationStatus, State state, Pageable pageable);
 
     List<Reservation> findAllByUserAndReservationStatusAndState(
             User user, ReservationStatus reservationStatus, State state);
-
-    Optional<Reservation> findByIdAndState(Long id, State state); //
-
-    List<Reservation> findAllByStoreIdAndState(Long storeId, State state);
-
-    List<Reservation> findAllByStoreIdAndReservationStatus(
-            Long storeId, ReservationStatus reservationStatus);
-
-    List<Reservation> findAllByStoreIdAndReservationStatusNot(
-            Long storeId, ReservationStatus reservationStatus);
 
     List<Reservation>
             findAllByReservedStoreChairAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
@@ -49,4 +44,13 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
                     LocalDateTime startDateTimeToSee,
                     LocalDateTime limit,
                     State state);
+
+    /** Admin Reservation */
+    List<Reservation> findAllByStoreIdAndState(Long storeId, State state);
+
+    List<Reservation> findAllByStoreIdAndReservationStatusAndState(
+            Long storeId, ReservationStatus reservationStatus, State state);
+
+    List<Reservation> findAllByStoreIdAndReservationStatusNot( // Todo : State 필드 체크
+            Long storeId, ReservationStatus reservationStatus);
 }

--- a/src/main/java/project/seatsence/src/utilization/dao/reservation/ReservationRepository.java
+++ b/src/main/java/project/seatsence/src/utilization/dao/reservation/ReservationRepository.java
@@ -24,10 +24,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findAllByUserAndReservationStatusAndState(
             User user, ReservationStatus reservationStatus, State state);
 
-    Reservation findByReservedStoreChairAndUserAndState(
-            StoreChair storeChair, User user, State state);
-
-    Optional<Reservation> findByIdAndState(Long id, State state);
+    Optional<Reservation> findByIdAndState(Long id, State state); //
 
     List<Reservation> findAllByStoreIdAndState(Long storeId, State state);
 

--- a/src/main/java/project/seatsence/src/utilization/service/reservation/AdminReservationService.java
+++ b/src/main/java/project/seatsence/src/utilization/service/reservation/AdminReservationService.java
@@ -2,6 +2,7 @@ package project.seatsence.src.utilization.service.reservation;
 
 import static project.seatsence.global.code.ResponseCode.RESERVATION_NOT_FOUND;
 import static project.seatsence.global.entity.BaseTimeAndStateEntity.State.*;
+import static project.seatsence.src.utilization.domain.reservation.ReservationStatus.*;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,38 +23,52 @@ public class AdminReservationService {
 
     public void reservationApprove(Long reservationId) {
         Reservation reservation = reservationService.findByIdAndState(reservationId);
-        reservation.setReservationStatus(ReservationStatus.APPROVED);
+        reservation.setReservationStatus(APPROVED);
     }
 
     public void reservationReject(Long reservationId) {
         Reservation reservation = reservationService.findByIdAndState(reservationId);
-        reservation.setReservationStatus(ReservationStatus.REJECTED);
+        reservation.setReservationStatus(REJECTED);
     }
 
     public List<Reservation> getAllReservationAndState(Long storeId) {
-        List<Reservation> reservationList =
-                reservationRepository.findAllByStoreIdAndState(storeId, ACTIVE);
+        List<Reservation> reservationList = findAllByStoreIdAndState(storeId);
         if (reservationList == null || reservationList.isEmpty())
             throw new BaseException(RESERVATION_NOT_FOUND);
         return reservationList;
     }
+
+    public List<Reservation> findAllByStoreIdAndState(Long storeId) {
+        return reservationRepository.findAllByStoreIdAndState(storeId, ACTIVE);
+    }
+
     // TODO TempStoreId 변경하기
     public List<Reservation> getPendingReservation(Long storeId) {
         List<Reservation> reservationPendingList =
-                reservationRepository.findAllByStoreIdAndReservationStatus(
-                        storeId, ReservationStatus.PENDING);
+                findAllByStoreIdAndReservationStatusAndState(storeId, PENDING);
         if (reservationPendingList == null || reservationPendingList.isEmpty())
             throw new BaseException(RESERVATION_NOT_FOUND);
         return reservationPendingList;
     }
 
+    public List<Reservation> findAllByStoreIdAndReservationStatusAndState(
+            Long storeId, ReservationStatus reservationStatus) {
+        return reservationRepository.findAllByStoreIdAndReservationStatusAndState(
+                storeId, reservationStatus, ACTIVE);
+    }
+
     public List<Reservation> getProcessedReservation(Long storeId) {
         List<Reservation> reservationProcessedList =
-                reservationRepository.findAllByStoreIdAndReservationStatusNot(
-                        storeId, ReservationStatus.PENDING);
+                findAllByStoreIdAndReservationStatusNot(storeId, PENDING);
 
         if (reservationProcessedList == null || reservationProcessedList.isEmpty())
             throw new BaseException(RESERVATION_NOT_FOUND);
         return reservationProcessedList;
+    }
+
+    public List<Reservation> findAllByStoreIdAndReservationStatusNot(
+            Long storeId, ReservationStatus reservationStatus) {
+        return reservationRepository.findAllByStoreIdAndReservationStatusNot(
+                storeId, reservationStatus); // Todo : ACTIVE 추가
     }
 }

--- a/src/main/java/project/seatsence/src/utilization/service/reservation/ReservationService.java
+++ b/src/main/java/project/seatsence/src/utilization/service/reservation/ReservationService.java
@@ -26,6 +26,10 @@ public class ReservationService {
                 .orElseThrow(() -> new BaseException(RESERVATION_NOT_FOUND));
     }
 
+    public Reservation save(Reservation reservation) {
+        return reservationRepository.save(reservation);
+    }
+
     public Boolean isPossibleTimeToManageReservationStatus(Reservation reservation) {
         LocalDateTime now = LocalDateTime.now();
         return now.isBefore(reservation.getEndSchedule());

--- a/src/main/java/project/seatsence/src/utilization/service/reservation/UserReservationService.java
+++ b/src/main/java/project/seatsence/src/utilization/service/reservation/UserReservationService.java
@@ -221,7 +221,8 @@ public class UserReservationService {
             String userEmail, String reservationStatus, Pageable pageable) {
         User user = userService.findUserByUserEmailAndState(userEmail);
 
-        // Todo : 대기중, 거절쪽 조회시 시간지난건 거절로 넘기기
+        // Todo : 대기중 조회시 시간지난건 거절로 넘기기
+        if (reservationStatus.equals(PENDING)) {}
 
         return SliceResponse.of(
                 reservationRepository

--- a/src/main/java/project/seatsence/src/utilization/service/reservation/UserReservationService.java
+++ b/src/main/java/project/seatsence/src/utilization/service/reservation/UserReservationService.java
@@ -221,6 +221,8 @@ public class UserReservationService {
             String userEmail, String reservationStatus, Pageable pageable) {
         User user = userService.findUserByUserEmailAndState(userEmail);
 
+        // Todo : 대기중, 거절쪽 조회시 시간지난건 거절로 넘기기
+
         return SliceResponse.of(
                 reservationRepository
                         .findAllByUserAndReservationStatusAndStateOrderByStartScheduleDesc(
@@ -229,6 +231,21 @@ public class UserReservationService {
                                 ACTIVE,
                                 pageable)
                         .map(UserReservationListResponse::from));
+    }
+
+    /**
+     * 현재 날짜시간이 예약 끝 일정을 지났는지 판단
+     *
+     * @param reservationEndSchedule : 예약 끝 일정
+     * @return 현재 날짜시간이 예약 끝 일정을 지났는지 여부 (true : 지났음)
+     */
+    public Boolean isReservationEndSchedulePassed(LocalDateTime reservationEndSchedule) {
+        Boolean result = false;
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isAfter(reservationEndSchedule)) {
+            result = true;
+        }
+        return result;
     }
 
     public void cancelReservation(Reservation reservation) {

--- a/src/main/java/project/seatsence/src/utilization/service/reservation/UserReservationService.java
+++ b/src/main/java/project/seatsence/src/utilization/service/reservation/UserReservationService.java
@@ -51,10 +51,6 @@ public class UserReservationService {
                 }
             };
 
-    public void saveReservation(Reservation reservation) {
-        reservationRepository.save(reservation);
-    }
-
     /**
      * 가능한 예약 시간 단위 유효성 체크
      *
@@ -285,16 +281,15 @@ public class UserReservationService {
                 setLimitTimeToGetAllReservationsOfThatDay(
                         allReservationsForSeatAndDateRequest.getReservationDateAndTime());
 
-        List<ReservationStatus> statusList = setPossibleReservationStatusToCancelReservation();
+        List<ReservationStatus> reservationStatuses =
+                setPossibleReservationStatusToCancelReservation();
 
         List<Reservation> reservations =
-                reservationRepository
-                        .findAllByReservedStoreChairAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
-                                storeChair,
-                                statusList,
-                                allReservationsForSeatAndDateRequest.getReservationDateAndTime(),
-                                limit,
-                                ACTIVE);
+                findAllByReservedStoreChairAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
+                        storeChair,
+                        reservationStatuses,
+                        allReservationsForSeatAndDateRequest.getReservationDateAndTime(),
+                        limit);
 
         List<AllReservationsForSeatAndDateResponse.ReservationForSeatAndDate> mappedReservations =
                 reservations.stream()
@@ -311,7 +306,6 @@ public class UserReservationService {
     public List<AllReservationsForSeatAndDateResponse.ReservationForSeatAndDate>
             getAllReservationsForSpaceAndDate(
                     AllReservationsForSeatAndDateRequest allReservationsForSeatAndDateRequest) {
-        Long startTime = System.currentTimeMillis();
         List<Reservation> reservationList = new ArrayList<>();
 
         StoreSpace storeSpace =
@@ -321,16 +315,15 @@ public class UserReservationService {
         LocalDateTime limit =
                 setLimitTimeToGetAllReservationsOfThatDay(
                         allReservationsForSeatAndDateRequest.getReservationDateAndTime());
-        List<ReservationStatus> statusList = setPossibleReservationStatusToCancelReservation();
+        List<ReservationStatus> reservationStatuses =
+                setPossibleReservationStatusToCancelReservation();
 
         List<Reservation> reservationsBySpace =
-                reservationRepository
-                        .findAllByReservedStoreSpaceAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
-                                storeSpace,
-                                statusList,
-                                allReservationsForSeatAndDateRequest.getReservationDateAndTime(),
-                                limit,
-                                ACTIVE);
+                findAllByReservedStoreSpaceAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
+                        storeSpace,
+                        reservationStatuses,
+                        allReservationsForSeatAndDateRequest.getReservationDateAndTime(),
+                        limit);
 
         reservationList = reservationsBySpace;
 
@@ -338,14 +331,11 @@ public class UserReservationService {
 
         for (StoreChair storeChair : storeChairList) {
             List<Reservation> reservationsByChairInSpace =
-                    reservationRepository
-                            .findAllByReservedStoreChairAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
-                                    storeChair,
-                                    statusList,
-                                    allReservationsForSeatAndDateRequest
-                                            .getReservationDateAndTime(),
-                                    limit,
-                                    ACTIVE);
+                    findAllByReservedStoreChairAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
+                            storeChair,
+                            reservationStatuses,
+                            allReservationsForSeatAndDateRequest.getReservationDateAndTime(),
+                            limit);
 
             for (Reservation reservation : reservationsByChairInSpace) {
                 reservationList.add(reservation);
@@ -374,11 +364,25 @@ public class UserReservationService {
         return Arrays.asList(PENDING, APPROVED);
     }
 
-    Reservation save(Reservation reservation) {
-        return reservationRepository.save(reservation);
+    public List<Reservation>
+            findAllByReservedStoreChairAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
+                    StoreChair storeChair,
+                    List<ReservationStatus> reservationStatuses,
+                    LocalDateTime startDateTimeToSee,
+                    LocalDateTime limit) {
+        return reservationRepository
+                .findAllByReservedStoreChairAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
+                        storeChair, reservationStatuses, startDateTimeToSee, limit, ACTIVE);
     }
 
-    Optional<Reservation> findByIdAndState(Long id) {
-        return reservationRepository.findByIdAndState(id, ACTIVE);
+    public List<Reservation>
+            findAllByReservedStoreSpaceAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
+                    StoreSpace storeSpace,
+                    List<ReservationStatus> reservationStatuses,
+                    LocalDateTime startDateTimeToSee,
+                    LocalDateTime limit) {
+        return reservationRepository
+                .findAllByReservedStoreSpaceAndReservationStatusInAndEndScheduleIsAfterAndEndScheduleIsBeforeAndState(
+                        storeSpace, reservationStatuses, startDateTimeToSee, limit, ACTIVE);
     }
 }


### PR DESCRIPTION
## Summary
- Close #177 

<br>

## Changes 
- 유저 예약 현황 조회 API에서 예약 상태가 '대기'인 데이터의 예약 끝 일정이 현 시간을 지났을 경우, 해당 데이터의 예약 상태가 '거절'로 바뀌도록 로직 추가
- Reservation패키지쪽 코드의 Service에서 Repository를 직접 사용하는 부분은 직접 사용하지 않도록 메소드 분리 진행

<br>

## To Reviewers
- @0binn Reservation패키지쪽 하는김에 영빈님 하신 부분도 메소드 분리 진행했습니다. 그런데 JpaRepository 사용하실 때, State 필드 체크안하신게 있더라고요! 그 부분 Todo 주석 달아두었으니 반영 부탁드리겠습니다.

<br>