### PR TITLE
가게 스페이스별 좌석 수정

### DIFF
--- a/src/main/java/project/seatsence/src/store/api/AdminStoreApi.java
+++ b/src/main/java/project/seatsence/src/store/api/AdminStoreApi.java
@@ -104,6 +104,16 @@ public class AdminStoreApi {
         return storeSpaceService.getStoreSpaceSeat(storeSpaceId);
     }
 
+    @Operation(
+            summary = "admin 스페이스의 정보 수정하기",
+            description = "예약 단위는 '스페이스', '좌석', '스페이스/좌석' 중 하나로 선택해야 합니다!")
+    @PatchMapping("/spaces/{store-space-id}")
+    public void putStoreSpaceSeat(
+            @PathVariable("store-space-id") Long storeSpaceId,
+            @RequestBody AdminStoreSpaceUpdateRequest adminStoreSeatUpdateRequest) {
+        storeSpaceService.updateStoreSpace(storeSpaceId, adminStoreSeatUpdateRequest);
+    }
+
     @Operation(summary = "admin 스페이스 삭제")
     @DeleteMapping("/spaces/{store-space-id}")
     public void deleteStoreSpace(@PathVariable("store-space-id") Long storeSpaceId) {
@@ -116,8 +126,8 @@ public class AdminStoreApi {
     @PostMapping("/spaces/{store-id}")
     public void postStoreSpace(
             @PathVariable("store-id") Long storeId,
-            @RequestBody @Valid AdminStoreSpaceCreateRequest request) {
-        storeSpaceService.save(storeId, request);
+            @RequestBody @Valid AdminStoreSpaceCreateRequest adminStoreSpaceCreateRequest) {
+        storeSpaceService.save(storeId, adminStoreSpaceCreateRequest);
     }
 
     @Operation(summary = "직원 등록을 위한 유저 검색")

--- a/src/main/java/project/seatsence/src/store/dao/StoreChairRepository.java
+++ b/src/main/java/project/seatsence/src/store/dao/StoreChairRepository.java
@@ -14,5 +14,5 @@ public interface StoreChairRepository extends JpaRepository<StoreChair, Long> {
 
     Optional<StoreChair> findByIdAndState(Long id, State state);
 
-    List<StoreChair> findByStoreSpaceAndState(StoreSpace storeSpace, State state);
+    List<StoreChair> findAllByStoreSpaceAndState(StoreSpace storeSpace, State state);
 }

--- a/src/main/java/project/seatsence/src/store/dao/StoreTableRepository.java
+++ b/src/main/java/project/seatsence/src/store/dao/StoreTableRepository.java
@@ -3,11 +3,12 @@ package project.seatsence.src.store.dao;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import project.seatsence.global.entity.BaseTimeAndStateEntity.State;
 import project.seatsence.src.store.domain.StoreSpace;
 import project.seatsence.src.store.domain.StoreTable;
 
 @Repository
 public interface StoreTableRepository extends JpaRepository<StoreTable, Long> {
 
-    List<StoreTable> findAllByStoreSpace(StoreSpace storeSpace);
+    List<StoreTable> findAllByStoreSpaceAndState(StoreSpace storeSpace, State state);
 }

--- a/src/main/java/project/seatsence/src/store/domain/StoreSpace.java
+++ b/src/main/java/project/seatsence/src/store/domain/StoreSpace.java
@@ -7,6 +7,8 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.*;
 import project.seatsence.global.entity.BaseEntity;
+import project.seatsence.global.utils.EnumUtils;
+import project.seatsence.src.store.dto.request.AdminStoreSpaceUpdateRequest;
 
 @Entity
 @Getter
@@ -37,4 +39,11 @@ public class StoreSpace extends BaseEntity {
 
     @OneToMany(mappedBy = "storeSpace", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StoreChair> storeChairList = new ArrayList<>();
+
+    public void updateBasicInformation(AdminStoreSpaceUpdateRequest request) {
+        this.name = request.getName();
+        this.reservationUnit =
+                EnumUtils.getEnumFromString(request.getReservationUnit(), ReservationUnit.class);
+        this.height = request.getHeight();
+    }
 }

--- a/src/main/java/project/seatsence/src/store/dto/request/AdminStoreSpaceUpdateRequest.java
+++ b/src/main/java/project/seatsence/src/store/dto/request/AdminStoreSpaceUpdateRequest.java
@@ -1,0 +1,38 @@
+package project.seatsence.src.store.dto.request;
+
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+public class AdminStoreSpaceUpdateRequest {
+
+    private String name;
+    private String reservationUnit;
+    private int height;
+
+    List<AdminStoreSpaceUpdateRequest.Table> tableList;
+
+    List<AdminStoreSpaceUpdateRequest.Chair> chairList;
+
+    @Validated
+    @Getter
+    public static class Table {
+        @NotBlank private String storeTableId;
+        @PositiveOrZero private int tableX;
+        @PositiveOrZero private int tableY;
+        @PositiveOrZero private int tableWidth;
+        @PositiveOrZero private int tableHeight;
+    }
+
+    @Validated
+    @Getter
+    public static class Chair {
+        @NotBlank private String storeChairId;
+        @PositiveOrZero int manageId;
+        @PositiveOrZero private int chairX;
+        @PositiveOrZero private int chairY;
+    }
+}

--- a/src/main/java/project/seatsence/src/store/dto/response/AdminOwnedStoreResponse.java
+++ b/src/main/java/project/seatsence/src/store/dto/response/AdminOwnedStoreResponse.java
@@ -15,6 +15,8 @@ public class AdminOwnedStoreResponse {
     public static class StoreResponse {
         private Long storeId;
         private String storeName;
+        private String introduction;
+        private String mainImage;
         boolean isOpenNow;
         boolean isClosedToday;
     }

--- a/src/main/java/project/seatsence/src/store/service/StoreChairService.java
+++ b/src/main/java/project/seatsence/src/store/service/StoreChairService.java
@@ -22,7 +22,7 @@ public class StoreChairService {
     }
 
     public List<StoreChair> findAllByStoreSpaceAndState(StoreSpace storeSpace) {
-        return storeChairRepository.findByStoreSpaceAndState(storeSpace, ACTIVE);
+        return storeChairRepository.findAllByStoreSpaceAndState(storeSpace, ACTIVE);
     }
 
     public StoreChair findByIdAndState(Long id) {

--- a/src/main/java/project/seatsence/src/store/service/StoreService.java
+++ b/src/main/java/project/seatsence/src/store/service/StoreService.java
@@ -58,6 +58,8 @@ public class StoreService {
                                         new AdminOwnedStoreResponse.StoreResponse(
                                                 store.getId(),
                                                 store.getStoreName(),
+                                                store.getIntroduction(),
+                                                store.getMainImage(),
                                                 isOpenNow(store),
                                                 isClosedToday(store)))
                         .collect(Collectors.toList());

--- a/src/main/java/project/seatsence/src/store/service/StoreTableService.java
+++ b/src/main/java/project/seatsence/src/store/service/StoreTableService.java
@@ -3,6 +3,7 @@ package project.seatsence.src.store.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import project.seatsence.global.entity.BaseTimeAndStateEntity.State;
 import project.seatsence.src.store.dao.StoreTableRepository;
 import project.seatsence.src.store.domain.StoreSpace;
 import project.seatsence.src.store.domain.StoreTable;
@@ -17,7 +18,7 @@ public class StoreTableService {
         storeTableRepository.saveAll(storeTableList);
     }
 
-    public List<StoreTable> findAllByStoreSpace(StoreSpace storeSpace) {
-        return storeTableRepository.findAllByStoreSpace(storeSpace);
+    public List<StoreTable> findAllByStoreSpaceAndState(StoreSpace storeSpace) {
+        return storeTableRepository.findAllByStoreSpaceAndState(storeSpace, State.ACTIVE);
     }
 }


### PR DESCRIPTION
## Summary
- Close #196 

<br>

## Changes 
- 가게 스페이스 정보 수정
- 기본정보(이름, 예약단위 등)와 좌석정보를 함께 수정한다고 하셔서 합쳤습니다! @sonmansu 
- 관리자 권한 가게 정보 조회에서 요청대로 응답 필드 추가하였습니다

<br>

## To Reviewers
- 좌석 수정할때 수정안되고 남아있는 것들, 새로 들어온것들 구별하기가 까다로워서 우선 기존 테이블, 좌석 다 지우고(INACTIVE) 새로 생성하도록 구현해두었어요

<br>