### PR TITLE
관리자 예약 현황 리스트의 예약 내역이 없는 경우 응답 코드를 성공으로 수정

### DIFF
--- a/src/main/java/project/seatsence/src/utilization/service/reservation/AdminReservationService.java
+++ b/src/main/java/project/seatsence/src/utilization/service/reservation/AdminReservationService.java
@@ -1,6 +1,7 @@
 package project.seatsence.src.utilization.service.reservation;
 
 import static project.seatsence.global.code.ResponseCode.RESERVATION_NOT_FOUND;
+import static project.seatsence.global.code.ResponseCode.SUCCESS_NO_CONTENT;
 import static project.seatsence.global.entity.BaseTimeAndStateEntity.State.*;
 import static project.seatsence.src.utilization.domain.reservation.ReservationStatus.*;
 
@@ -36,7 +37,7 @@ public class AdminReservationService {
         Slice<Reservation> reservationSlice =
                 findAllByStoreIdAndStateOrderByStartScheduleDesc(storeId, pageable);
         if (!reservationSlice.hasContent()) {
-            throw new BaseException(RESERVATION_NOT_FOUND);
+            throw new BaseException(SUCCESS_NO_CONTENT);
         }
         return reservationSlice;
     }
@@ -52,7 +53,7 @@ public class AdminReservationService {
                 findAllByStoreIdAndReservationStatusAndStateOrderByStartScheduleDesc(
                         storeId, PENDING, pageable);
         if (!reservationPendingSlice.hasContent()) {
-            throw new BaseException(RESERVATION_NOT_FOUND);
+            throw new BaseException(SUCCESS_NO_CONTENT);
         }
         return reservationPendingSlice;
     }
@@ -70,7 +71,7 @@ public class AdminReservationService {
                         storeId, PENDING, pageable);
 
         if (!reservationProcessedSlice.hasContent()) {
-            throw new BaseException(RESERVATION_NOT_FOUND);
+            throw new BaseException(SUCCESS_NO_CONTENT);
         }
         return reservationProcessedSlice;
     }


### PR DESCRIPTION
## Summary
- Close #236 

<br>

## Changes 
- 리스트 요청 시 내역이 없을 때의 응답을 RESERVATION_NOT_FOUND에서 SUCCESS_NO_CONTENT로 수정

<br>

## To Reviewers
- 

<br>