### PR TITLE
가게 기본 정보 등록 시 이미지 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 
 	//Json
 	compileOnly group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+
+	// s3 image upload
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/project/seatsence/global/config/S3Config.java
+++ b/src/main/java/project/seatsence/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package project.seatsence.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${AWS_ACCESS_KEY}")
+    private String accessKey;
+
+    @Value("${AWS_SECRET_KEY}")
+    private String secretKey;
+
+    @Value("${AWS_REGION}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/project/seatsence/src/store/api/AdminStoreApi.java
+++ b/src/main/java/project/seatsence/src/store/api/AdminStoreApi.java
@@ -5,6 +5,7 @@ import static project.seatsence.global.constants.Constants.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import project.seatsence.global.config.security.JwtProvider;
 import project.seatsence.src.store.domain.CustomReservationField;
 import project.seatsence.src.store.domain.Store;
@@ -22,10 +24,7 @@ import project.seatsence.src.store.dto.StoreMemberMapper;
 import project.seatsence.src.store.dto.request.*;
 import project.seatsence.src.store.dto.response.*;
 import project.seatsence.src.store.dto.response.AdminNewBusinessInformationResponse;
-import project.seatsence.src.store.service.StoreCustomService;
-import project.seatsence.src.store.service.StoreMemberService;
-import project.seatsence.src.store.service.StoreService;
-import project.seatsence.src.store.service.StoreSpaceService;
+import project.seatsence.src.store.service.*;
 
 @RequestMapping("/v1/stores/admins")
 @RestController
@@ -39,6 +38,7 @@ public class AdminStoreApi {
     private final StoreMemberService storeMemberService;
     private final StoreService storeService;
     private final StoreCustomService storeCustomService;
+    private final S3Service s3Service;
 
     @Operation(
             summary = "관리 권한이 있는 모든 가게 정보 가져오기",
@@ -63,8 +63,17 @@ public class AdminStoreApi {
     @PatchMapping("/basic-information/{store-id}")
     public void postStoreBasicInformation(
             @PathVariable("store-id") Long storeId,
-            @RequestBody @Valid AdminStoreBasicInformationRequest request) {
-        storeService.updateBasicInformation(request, storeId);
+            @RequestParam("storeName") String storeName,
+            @RequestParam("address") String address,
+            @RequestParam("detailAddress") String detailAddress,
+            @RequestParam("category") String category,
+            @RequestParam("introduction") String introduction,
+            @RequestParam(value = "file", required = false) List<MultipartFile> files)
+            throws IOException {
+        AdminStoreBasicInformationRequest request =
+                AdminStoreBasicInformationRequest.createAdminStoreBasicInformationRequest(
+                        storeName, address, detailAddress, category, introduction);
+        storeService.updateBasicInformation(request, storeId, files);
     }
 
     @Operation(summary = "admin 가게 운영시간 정보 가져오기")

--- a/src/main/java/project/seatsence/src/store/dao/StoreImageRepository.java
+++ b/src/main/java/project/seatsence/src/store/dao/StoreImageRepository.java
@@ -1,0 +1,8 @@
+package project.seatsence.src.store.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import project.seatsence.src.store.domain.StoreImage;
+
+@Repository
+public interface StoreImageRepository extends JpaRepository<StoreImage, Long> {}

--- a/src/main/java/project/seatsence/src/store/domain/Store.java
+++ b/src/main/java/project/seatsence/src/store/domain/Store.java
@@ -102,7 +102,6 @@ public class Store extends BaseEntity {
         this.address = request.getAddress();
         this.detailAddress = request.getDetailAddress();
         this.category = EnumUtils.getEnumFromString(request.getCategory(), Category.class);
-        this.mainImage = request.getMainImage();
         this.introduction = request.getIntroduction();
     }
 
@@ -132,5 +131,9 @@ public class Store extends BaseEntity {
 
     public void updateIsClosedToday(boolean isClosedToday) {
         this.isClosedToday = isClosedToday;
+    }
+
+    public void updateMainImage(String url) {
+        this.mainImage = url;
     }
 }

--- a/src/main/java/project/seatsence/src/store/domain/StoreImage.java
+++ b/src/main/java/project/seatsence/src/store/domain/StoreImage.java
@@ -1,0 +1,25 @@
+package project.seatsence.src.store.domain;
+
+import javax.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class StoreImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(targetEntity = Store.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    public String url;
+
+    public static StoreImage createStoreImage(Store store, String url) {
+        StoreImage storeImage = new StoreImage();
+        storeImage.store = store;
+        storeImage.url = url;
+        return storeImage;
+    }
+}

--- a/src/main/java/project/seatsence/src/store/dto/request/AdminStoreBasicInformationRequest.java
+++ b/src/main/java/project/seatsence/src/store/dto/request/AdminStoreBasicInformationRequest.java
@@ -7,8 +7,22 @@ public class AdminStoreBasicInformationRequest {
     private String storeName;
     private String address;
     private String detailAddress;
-
     private String category;
-    private String mainImage; // TODO 메인 이미지 및 이미지 리스트 전송
     private String introduction;
+
+    public static AdminStoreBasicInformationRequest createAdminStoreBasicInformationRequest(
+            String storeName,
+            String address,
+            String detailAddress,
+            String category,
+            String introduction) {
+        AdminStoreBasicInformationRequest adminStoreBasicInformationRequest =
+                new AdminStoreBasicInformationRequest();
+        adminStoreBasicInformationRequest.storeName = storeName;
+        adminStoreBasicInformationRequest.address = address;
+        adminStoreBasicInformationRequest.detailAddress = detailAddress;
+        adminStoreBasicInformationRequest.category = category;
+        adminStoreBasicInformationRequest.introduction = introduction;
+        return adminStoreBasicInformationRequest;
+    }
 }

--- a/src/main/java/project/seatsence/src/store/service/S3Service.java
+++ b/src/main/java/project/seatsence/src/store/service/S3Service.java
@@ -1,0 +1,54 @@
+package project.seatsence.src.store.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Service {
+
+    @Value("${AWS_S3_BUCKET}")
+    private String bucket;
+
+    private final AmazonS3Client amazonS3Client;
+
+    // MultipartFile을 전달받아 File로 전환한 후 S3에 업로드
+    public List<String> upload(List<MultipartFile> files, String dirName, Long storeId)
+            throws IOException {
+        List<String> imagePathList = new ArrayList<>();
+        int index = 1;
+        for (MultipartFile file : files) {
+            String originalName = file.getOriginalFilename(); // 파일 이름
+            assert originalName != null;
+            String extension = originalName.split("\\.")[1]; // 파일 확장자
+            String fileName = storeId + "_" + index + "." + extension;
+            String filePath = dirName + "/" + fileName;
+            long size = file.getSize(); // 파일 크기
+
+            ObjectMetadata objectMetaData = new ObjectMetadata();
+            objectMetaData.setContentType(file.getContentType());
+            objectMetaData.setContentLength(size);
+
+            // S3에 업로드
+            amazonS3Client.putObject(
+                    new PutObjectRequest(bucket, filePath, file.getInputStream(), objectMetaData)
+                            .withCannedAcl(CannedAccessControlList.PublicRead));
+
+            String imagePath = amazonS3Client.getUrl(bucket, filePath).toString(); // 접근가능한 URL 가져오기
+            imagePathList.add(imagePath);
+            index++;
+        }
+        return imagePathList;
+    }
+}

--- a/src/main/java/project/seatsence/src/store/service/StoreImageService.java
+++ b/src/main/java/project/seatsence/src/store/service/StoreImageService.java
@@ -1,0 +1,24 @@
+package project.seatsence.src.store.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import project.seatsence.src.store.dao.StoreImageRepository;
+import project.seatsence.src.store.domain.Store;
+import project.seatsence.src.store.domain.StoreImage;
+
+@Service
+@RequiredArgsConstructor
+public class StoreImageService {
+
+    private final StoreImageRepository storeImageRepository;
+
+    public void saveStoreImageList(Store store, List<String> urls) {
+        List<StoreImage> storeImageList = new ArrayList<>();
+        for (int i = 1; i < urls.size(); i++) {
+            storeImageList.add(StoreImage.createStoreImage(store, urls.get(i)));
+        }
+        storeImageRepository.saveAll(storeImageList);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,17 @@ spring:
       pageable:
         one-indexed-parameters: true
         default-page-size: 8
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+    region:
+      static: ${AWS_REGION}
+    stack:
+        auto: false
 
 server:
   port: 7777


### PR DESCRIPTION
## Summary
- Close #151  

<br>

## Changes 
- 가게 기본정보 등록 시 이미지도 함께 업로드
- 업로드 된 image는 s3 `store-images/` 경로에 가게 `store-id_order(1, 2..).확장자` 형태의 파일 이름으로 저장

<br>

## To Reviewers
- 

<br>