### PR TITLE
가게 기본 정보 등록 시 origin image 없이도 저장되도록 required false 옵션 추가

### DIFF
--- a/src/main/java/project/seatsence/src/store/api/admin/AdminStoreApi.java
+++ b/src/main/java/project/seatsence/src/store/api/admin/AdminStoreApi.java
@@ -62,7 +62,7 @@ public class AdminStoreApi {
             @RequestParam("category") String category,
             @RequestParam("introduction") String introduction,
             @RequestParam("telNum") String telNum,
-            @RequestParam("originImages") List<String> originImages,
+            @RequestParam(value = "originImages", required = false) List<String> originImages,
             @RequestParam(value = "file", required = false) List<MultipartFile> files)
             throws IOException {
         StoreBasicInformationRequest request =

--- a/src/main/java/project/seatsence/src/store/service/S3Service.java
+++ b/src/main/java/project/seatsence/src/store/service/S3Service.java
@@ -26,27 +26,32 @@ public class S3Service {
     public List<String> upload(List<MultipartFile> files, String dirName, Long storeId)
             throws IOException {
         List<String> imagePathList = new ArrayList<>();
-        for (MultipartFile file : files) {
-            String originalName = file.getOriginalFilename(); // 파일 이름
-            assert originalName != null;
-            String extension = originalName.split("\\.")[1]; // 파일 확장자
-            String fileName = storeId + "_" + StringUtils.makeRandomString() + "." + extension;
-            String filePath = dirName + "/" + fileName;
-            long size = file.getSize(); // 파일 크기
+        if (files != null && !files.isEmpty()) {
+            for (MultipartFile file : files) {
+                String originalName = file.getOriginalFilename(); // 파일 이름
+                assert originalName != null;
+                String extension = originalName.split("\\.")[1]; // 파일 확장자
+                String fileName = storeId + "_" + StringUtils.makeRandomString() + "." + extension;
+                String filePath = dirName + "/" + fileName;
+                long size = file.getSize(); // 파일 크기
 
-            ObjectMetadata objectMetaData = new ObjectMetadata();
-            objectMetaData.setContentType(file.getContentType());
-            objectMetaData.setContentLength(size);
+                ObjectMetadata objectMetaData = new ObjectMetadata();
+                objectMetaData.setContentType(file.getContentType());
+                objectMetaData.setContentLength(size);
 
-            // S3에 업로드
-            amazonS3Client.putObject(
-                    new PutObjectRequest(bucket, filePath, file.getInputStream(), objectMetaData)
-                            .withCannedAcl(CannedAccessControlList.PublicRead));
+                // S3에 업로드
+                amazonS3Client.putObject(
+                        new PutObjectRequest(
+                                        bucket, filePath, file.getInputStream(), objectMetaData)
+                                .withCannedAcl(CannedAccessControlList.PublicRead));
 
-            String imagePath = amazonS3Client.getUrl(bucket, filePath).toString(); // 접근가능한 URL 가져오기
-            imagePathList.add(imagePath);
+                String imagePath =
+                        amazonS3Client.getUrl(bucket, filePath).toString(); // 접근가능한 URL 가져오기
+                imagePathList.add(imagePath);
+            }
+            return imagePathList;
         }
-        return imagePathList;
+        return null;
     }
 
     public void deleteOriginImages(Long storeId) {

--- a/src/main/java/project/seatsence/src/store/service/StoreService.java
+++ b/src/main/java/project/seatsence/src/store/service/StoreService.java
@@ -111,7 +111,9 @@ public class StoreService {
         }
         List<String> uploads =
                 s3Service.upload(files, STORE_IMAGE_S3_PATH, store.getId()); // 새로 추가된 이미지들 업로드
-        originImages.addAll(uploads); // 기존에 가지고 있던 이미지들 + 새로 추가된 이미지들
+        if (uploads != null) {
+            originImages.addAll(uploads); // 기존에 가지고 있던 이미지들 + 새로 추가된 이미지들
+        }
         String newImages = objectMapper.writeValueAsString(originImages); // 이미지 경로 json으로 변환
         store.updateImages(newImages); // json string 저장
     }


### PR DESCRIPTION
## Summary
- hotfix

<br>

## Changes 
- 가게 기본정보 등록 시 기존 이미지가 없어도 등록되도록 required false 옵션을 추가합니다.

<br>

## To Reviewers
- OriginImages required = false 옵션 추가

<br>