### PR TITLE
관리자 예약 리스트 정렬기준 수정

### DIFF
--- a/src/main/java/project/seatsence/src/utilization/api/reservation/AdminReservationApi.java
+++ b/src/main/java/project/seatsence/src/utilization/api/reservation/AdminReservationApi.java
@@ -39,8 +39,7 @@ public class AdminReservationApi {
         adminReservationService.reservationReject(reservationId);
     }
 
-    @Operation(summary = "admin 예약 전체 리스트",
-            description = "정렬 기준: 예약시작일자 내림차순")
+    @Operation(summary = "admin 예약 전체 리스트", description = "정렬 기준: 예약시작일자 내림차순")
     @GetMapping("/{store-id}/all-list")
     public SliceResponse<AdminReservationListResponse.ReservationResponse> entireReservationList(
             @PathVariable("store-id") Long storeId,
@@ -55,8 +54,7 @@ public class AdminReservationApi {
         return sliceResponse;
     }
 
-    @Operation(summary = "admin 예약 대기 리스트",
-            description = "정렬 기준: 예약시작일자 오름차순")
+    @Operation(summary = "admin 예약 대기 리스트", description = "정렬 기준: 예약시작일자 오름차순")
     @GetMapping("/{store-id}/pending-list")
     public SliceResponse<AdminReservationListResponse.ReservationResponse> pendingReservationList(
             @PathVariable("store-id") Long storeId,
@@ -71,8 +69,7 @@ public class AdminReservationApi {
         return sliceResponse;
     }
 
-    @Operation(summary = "admin 예약 처리 완료 리스트",
-            description = "정렬 기준: 업데이트시간 내림차순")
+    @Operation(summary = "admin 예약 처리 완료 리스트", description = "정렬 기준: 업데이트시간 내림차순")
     @GetMapping("/{store-id}/processed-list")
     public SliceResponse<AdminReservationListResponse.ReservationResponse> processedReservationList(
             @PathVariable("store-id") Long storeId,

--- a/src/main/java/project/seatsence/src/utilization/api/reservation/AdminReservationApi.java
+++ b/src/main/java/project/seatsence/src/utilization/api/reservation/AdminReservationApi.java
@@ -39,7 +39,8 @@ public class AdminReservationApi {
         adminReservationService.reservationReject(reservationId);
     }
 
-    @Operation(summary = "admin 예약 전체 리스트")
+    @Operation(summary = "admin 예약 전체 리스트",
+            description = "정렬 기준: 예약시작일자 내림차순")
     @GetMapping("/{store-id}/all-list")
     public SliceResponse<AdminReservationListResponse.ReservationResponse> entireReservationList(
             @PathVariable("store-id") Long storeId,
@@ -54,7 +55,8 @@ public class AdminReservationApi {
         return sliceResponse;
     }
 
-    @Operation(summary = "admin 예약 대기 리스트")
+    @Operation(summary = "admin 예약 대기 리스트",
+            description = "정렬 기준: 예약시작일자 오름차순")
     @GetMapping("/{store-id}/pending-list")
     public SliceResponse<AdminReservationListResponse.ReservationResponse> pendingReservationList(
             @PathVariable("store-id") Long storeId,
@@ -69,7 +71,8 @@ public class AdminReservationApi {
         return sliceResponse;
     }
 
-    @Operation(summary = "admin 예약 처리 완료 리스트")
+    @Operation(summary = "admin 예약 처리 완료 리스트",
+            description = "정렬 기준: 업데이트시간 내림차순")
     @GetMapping("/{store-id}/processed-list")
     public SliceResponse<AdminReservationListResponse.ReservationResponse> processedReservationList(
             @PathVariable("store-id") Long storeId,

--- a/src/main/java/project/seatsence/src/utilization/dao/reservation/ReservationRepository.java
+++ b/src/main/java/project/seatsence/src/utilization/dao/reservation/ReservationRepository.java
@@ -56,9 +56,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     Slice<Reservation> findAllByStoreIdAndStateOrderByStartScheduleDesc(
             Long storeId, State state, Pageable pageable);
 
-    Slice<Reservation> findAllByStoreIdAndReservationStatusAndStateOrderByStartScheduleDesc(
+    Slice<Reservation> findAllByStoreIdAndReservationStatusAndStateOrderByStartScheduleAsc(
             Long storeId, ReservationStatus reservationStatus, State state, Pageable pageable);
 
-    Slice<Reservation> findAllByStoreIdAndReservationStatusNotAndStateOrderByStartScheduleDesc(
+    Slice<Reservation> findAllByStoreIdAndReservationStatusNotAndStateOrderByUpdatedAtDesc(
             Long storeId, ReservationStatus reservationStatus, State state, Pageable pageable);
 }

--- a/src/main/java/project/seatsence/src/utilization/service/reservation/AdminReservationService.java
+++ b/src/main/java/project/seatsence/src/utilization/service/reservation/AdminReservationService.java
@@ -51,7 +51,7 @@ public class AdminReservationService {
 
     public Slice<Reservation> getPendingReservation(Long storeId, Pageable pageable) {
         Slice<Reservation> reservationPendingSlice =
-                findAllByStoreIdAndReservationStatusAndStateOrderByStartScheduleDesc(
+                findAllByStoreIdAndReservationStatusAndStateOrderByStartScheduleAsc(
                         storeId, PENDING, pageable);
         if (!reservationPendingSlice.hasContent()) {
             throw new BaseException(SUCCESS_NO_CONTENT);
@@ -59,16 +59,16 @@ public class AdminReservationService {
         return reservationPendingSlice;
     }
 
-    public Slice<Reservation> findAllByStoreIdAndReservationStatusAndStateOrderByStartScheduleDesc(
+    public Slice<Reservation> findAllByStoreIdAndReservationStatusAndStateOrderByStartScheduleAsc(
             Long storeId, ReservationStatus reservationStatus, Pageable pageable) {
         return reservationRepository
-                .findAllByStoreIdAndReservationStatusAndStateOrderByStartScheduleDesc(
+                .findAllByStoreIdAndReservationStatusAndStateOrderByStartScheduleAsc(
                         storeId, reservationStatus, ACTIVE, pageable);
     }
 
     public Slice<Reservation> getProcessedReservation(Long storeId, Pageable pageable) {
         Slice<Reservation> reservationProcessedSlice =
-                findAllByStoreIdAndReservationStatusNotAndStateOrderByStartScheduleDesc(
+                findAllByStoreIdAndReservationStatusNotAndStateOrderByUpdatedAtDesc(
                         storeId, PENDING, pageable);
 
         if (!reservationProcessedSlice.hasContent()) {
@@ -78,10 +78,10 @@ public class AdminReservationService {
     }
 
     public Slice<Reservation>
-            findAllByStoreIdAndReservationStatusNotAndStateOrderByStartScheduleDesc(
+            findAllByStoreIdAndReservationStatusNotAndStateOrderByUpdatedAtDesc(
                     Long storeId, ReservationStatus reservationStatus, Pageable pageable) {
         return reservationRepository
-                .findAllByStoreIdAndReservationStatusNotAndStateOrderByStartScheduleDesc(
+                .findAllByStoreIdAndReservationStatusNotAndStateOrderByUpdatedAtDesc(
                         storeId, reservationStatus, ACTIVE, pageable);
     }
 

--- a/src/main/java/project/seatsence/src/utilization/service/reservation/AdminReservationService.java
+++ b/src/main/java/project/seatsence/src/utilization/service/reservation/AdminReservationService.java
@@ -77,9 +77,8 @@ public class AdminReservationService {
         return reservationProcessedSlice;
     }
 
-    public Slice<Reservation>
-            findAllByStoreIdAndReservationStatusNotAndStateOrderByUpdatedAtDesc(
-                    Long storeId, ReservationStatus reservationStatus, Pageable pageable) {
+    public Slice<Reservation> findAllByStoreIdAndReservationStatusNotAndStateOrderByUpdatedAtDesc(
+            Long storeId, ReservationStatus reservationStatus, Pageable pageable) {
         return reservationRepository
                 .findAllByStoreIdAndReservationStatusNotAndStateOrderByUpdatedAtDesc(
                         storeId, reservationStatus, ACTIVE, pageable);


### PR DESCRIPTION
## Summary
- Fixes #260 

<br>

## Changes 
- 예약 대기중 리스트 정렬기준을 예약시작일자 오름차순으로 수정
- 예약 처리완료 리스트 정렬기준을 업데이트시간 내림차순으로 수정

<br>

## To Reviewers
- 

<br>
