### PR TITLE
쿼리 최적화 및 응답 객체를 위한 mapper 생성

### DIFF
--- a/src/main/java/project/seatsence/src/store/dao/StoreSpaceRepository.java
+++ b/src/main/java/project/seatsence/src/store/dao/StoreSpaceRepository.java
@@ -5,6 +5,8 @@ import static project.seatsence.global.entity.BaseTimeAndStateEntity.State;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import project.seatsence.src.store.domain.Store;
 import project.seatsence.src.store.domain.StoreSpace;
@@ -15,4 +17,9 @@ public interface StoreSpaceRepository extends JpaRepository<StoreSpace, Long> {
     List<StoreSpace> findAllByStoreAndState(Store store, State state);
 
     Optional<StoreSpace> findByIdAndState(Long id, State state);
+
+    @Query(
+            "SELECT s FROM StoreSpace s JOIN FETCH s.storeTableList WHERE s.id = :id AND s.state = :state")
+    Optional<StoreSpace> findByIdAndStateWithTables(
+            @Param("id") Long id, @Param("state") State state);
 }

--- a/src/main/java/project/seatsence/src/store/domain/StoreChair.java
+++ b/src/main/java/project/seatsence/src/store/domain/StoreChair.java
@@ -27,7 +27,7 @@ public class StoreChair extends BaseEntity {
     private int manageId;
 
     @NotNull
-    @ManyToOne
+    @ManyToOne(targetEntity = Store.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
 

--- a/src/main/java/project/seatsence/src/store/domain/StoreTable.java
+++ b/src/main/java/project/seatsence/src/store/domain/StoreTable.java
@@ -21,7 +21,7 @@ public class StoreTable extends BaseEntity {
     private Long id;
 
     @NotNull
-    @ManyToOne
+    @ManyToOne(targetEntity = Store.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
 

--- a/src/main/java/project/seatsence/src/store/mapper/StoreChairMapper.java
+++ b/src/main/java/project/seatsence/src/store/mapper/StoreChairMapper.java
@@ -1,0 +1,15 @@
+package project.seatsence.src.store.mapper;
+
+import project.seatsence.src.store.domain.StoreChair;
+import project.seatsence.src.store.dto.response.admin.space.StoreSpaceChairResponse;
+
+public class StoreChairMapper {
+    public static StoreSpaceChairResponse convertToStoreSpaceChairResponse(StoreChair storeChair) {
+        return StoreSpaceChairResponse.builder()
+                .id(storeChair.getId())
+                .manageId(storeChair.getManageId())
+                .chairX(storeChair.getChairX())
+                .chairY(storeChair.getChairY())
+                .build();
+    }
+}

--- a/src/main/java/project/seatsence/src/store/mapper/StoreTableMapper.java
+++ b/src/main/java/project/seatsence/src/store/mapper/StoreTableMapper.java
@@ -1,0 +1,16 @@
+package project.seatsence.src.store.mapper;
+
+import project.seatsence.src.store.domain.StoreTable;
+import project.seatsence.src.store.dto.response.admin.space.StoreSpaceTableResponse;
+
+public class StoreTableMapper {
+    public static StoreSpaceTableResponse convertToStoreSpaceTableResponse(StoreTable storeTable) {
+        return StoreSpaceTableResponse.builder()
+                .id(storeTable.getId())
+                .width(storeTable.getWidth())
+                .height(storeTable.getHeight())
+                .tableX(storeTable.getTableX())
+                .tableY(storeTable.getTableY())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #320 

<br>

## Changes 
- storeChair, storeTable의 응답 객체 생성을 위한 mapper 생성
- 쿼리 실행횟수 감소를 위해, storeSpace 조회시 storeTable에 대해 fetch join 적용 (storeChair에 적용하지 않은 이유는, JPA에서 1대다 관계의 객체를 한 번에 2개 이상 즉시 조회할 경우 MultipleBagFetchException 발생하기 때문)
- store 테이블을 불필요하게 조회하고 있는 문제 해결 : store에 대해 fetch 전략 LAZY로 수정

<br>

## To Reviewers
- 

<br>